### PR TITLE
add Azure support and a bit of refactoring

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.3.2"
+appVersion: "0.4.0"
 description: A Helm chart for thanos
 name: thanos
-version: 0.3.0
+version: 0.4.0

--- a/thanos/templates/compact-service-http.yaml
+++ b/thanos/templates/compact-service-http.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.compact.enabled }}
 {{- if .Values.compact.httpService.enabled }}
 apiVersion: v1
 kind: Service
@@ -30,4 +31,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: compact
+{{- end -}}
 {{- end -}}

--- a/thanos/templates/configmap-s3.yaml
+++ b/thanos/templates/configmap-s3.yaml
@@ -1,3 +1,4 @@
+# TODO: this needs to be removed
 {{- if .Values.s3.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -49,7 +49,9 @@ spec:
             {{- if .Values.query.tlsServer.enabled }}
             - "--grpc-server-tls-cert=/thanos-tls-server/server.crt"
             - "--grpc-server-tls-key=/thanos-tls-server/server.key"
+            {{- if .Values.query.tlsServer.ca }}
             - "--grpc-server-tls-client-ca=/thanos-tls-server/ca.crt"
+            {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/thanos/templates/query-secret-tls-client.yaml
+++ b/thanos/templates/query-secret-tls-client.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.query.tlsClient.enabled }}
 apiVersion: v1
 data:
-  client.crt: {{ .Values.query.tlsClient.cert }}
-  client.key: {{ .Values.query.tlsClient.key }}
-  ca.crt: {{ .Values.query.tlsClient.ca }}
+  client.crt: {{ .Values.query.tlsClient.cert | b64enc }}
+  client.key: {{ .Values.query.tlsClient.key | b64enc }}
+  ca.crt: {{ .Values.query.tlsClient.ca | b64enc }}
 kind: Secret
 metadata:
   name: {{ include "thanos.fullname" . }}-thanos-query-tls-client

--- a/thanos/templates/query-secret-tls-server.yaml
+++ b/thanos/templates/query-secret-tls-server.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.query.tlsServer.enabled }}
 apiVersion: v1
 data:
-  server.crt: {{ .Values.query.tlsServer.cert }}
-  server.key: {{ .Values.query.tlsServer.key }}
-  ca.crt: {{ .Values.query.tlsServer.ca }}
+  server.crt: {{ .Values.query.tlsServer.cert | b64enc }}
+  server.key: {{ .Values.query.tlsServer.key | b64enc }}
+  ca.crt: {{ .Values.query.tlsServer.ca | b64enc }}
 kind: Secret
 metadata:
   name: {{ include "thanos.fullname" . }}-thanos-query-tls-server

--- a/thanos/templates/query-service-cluster.yaml
+++ b/thanos/templates/query-service-cluster.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.query.enabled }}
 {{- if .Values.query.clusterService.enabled }}
 {{- if not .Values.query.clusterDisabled }}
 apiVersion: v1
@@ -32,4 +33,5 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: query
 {{- end }}
+{{- end -}}
 {{- end -}}

--- a/thanos/templates/query-service-grpc.yaml
+++ b/thanos/templates/query-service-grpc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.query.enabled }}
 {{- if .Values.query.grpcService.enabled }}
 apiVersion: v1
 kind: Service
@@ -30,4 +31,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: query
+{{- end -}}
 {{- end -}}

--- a/thanos/templates/query-service-http.yaml
+++ b/thanos/templates/query-service-http.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.query.enabled }}
 {{- if .Values.query.httpService.enabled }}
 apiVersion: v1
 kind: Service
@@ -30,4 +31,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: query
+{{- end -}}
 {{- end -}}

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -38,14 +38,28 @@ spec:
             {{- if .Values.store.clusterDisabled }}
             - "--cluster.disable"
             {{- end }}
+            # TODO: this should be removed (deprecated in favor of objstore.config)
             {{- if .Values.s3.enabled }}
             - "--objstore.config-file=/thanos-s3/s3.yaml"
+            {{- end }}
+            {{- if .Values.objectStorageConfig.enabled }}
+            - "--objstore.config=$(OBJSTORE_CONFIG)"
             {{- end }}
             {{- if .Values.store.tlsServer.enabled }}
             - "--grpc-server-tls-cert=/thanos-tls-server/server.crt"
             - "--grpc-server-tls-key=/thanos-tls-server/server.key"
+            {{- if .Values.store.tlsServer.ca }}
             - "--grpc-server-tls-client-ca=/thanos-tls-server/ca.crt"
             {{- end }}
+            {{- end }}
+          {{- if .Values.objectStorageConfig.enabled }}
+          env:
+          - name: OBJSTORE_CONFIG
+            valueFrom:
+              secretKeyRef:
+                key: {{ .Values.objectStorageConfig.key }}
+                name: {{ .Values.objectStorageConfig.name }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.store.deployment.container.httpPort }}

--- a/thanos/templates/store-secret-tls-server.yaml
+++ b/thanos/templates/store-secret-tls-server.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.store.tlsServer.enabled }}
 apiVersion: v1
 data:
-  server.crt: {{ .Values.store.tlsServer.cert }}
-  server.key: {{ .Values.store.tlsServer.key }}
-  ca.crt: {{ .Values.store.tlsServer.ca }}
+  server.crt: {{ .Values.store.tlsServer.cert | b64enc }}
+  server.key: {{ .Values.store.tlsServer.key | b64enc }}
+  ca.crt: {{ .Values.store.tlsServer.ca | b64enc }}
 kind: Secret
 metadata:
   name: {{ include "thanos.fullname" . }}-thanos-store-tls-server

--- a/thanos/templates/store-service-cluster.yaml
+++ b/thanos/templates/store-service-cluster.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.store.enabled }}
 {{- if .Values.store.clusterService.enabled }}
 {{- if not .Values.store.clusterDisabled }}
 apiVersion: v1
@@ -31,5 +32,6 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: store
-{{- end }}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/thanos/templates/store-service-grpc.yaml
+++ b/thanos/templates/store-service-grpc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.store.enabled }}
 {{- if .Values.store.grpcService.enabled }}
 apiVersion: v1
 kind: Service
@@ -30,4 +31,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: store
+{{- end -}}
 {{- end -}}

--- a/thanos/templates/store-service-http.yaml
+++ b/thanos/templates/store-service-http.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.store.enabled }}
 {{- if .Values.store.httpService.enabled }}
 apiVersion: v1
 kind: Service
@@ -30,4 +31,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: store
+{{- end -}}
 {{- end -}}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -1,8 +1,3 @@
-# Default values for thanos-store.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-
 image:
   repository: improbable/thanos
   tag: v0.3.2
@@ -11,6 +6,7 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# TODO: this should be removed in favor of objectStorageConfig, keeping it now for backward compatibility
 s3:
   enabled: false
   bucket: ""
@@ -19,21 +15,27 @@ s3:
   signatureV2: true
   encryptSse: false
 
+# Thanos object storage configuration (Azure Blob, EWS S3, etc.)
+# see ref: https://github.com/improbable-eng/thanos/blob/master/docs/storage.md
+objectStorageConfig:
+  enabled: false
+  key: thanos.yaml
+  name: thanos-objstore-config
 
 # Thanos store configuration
 store:
   enabled: true
   replicaCount: 1
-
   logLevel: debug
-
   clusterDisabled: true
 
-  # cert, key and ca are base64 encoded strings
+  # cert, key and ca are strings and can be overwritten using `helm install <chart> --set-file <key>=/path/to/file`
   tlsServer:
     enabled: false
+    # certificate and key for server TLS
     cert: ""
     key: ""
+    # CA to validate the remote client certificate
     ca: ""
 
   deployment:
@@ -102,19 +104,24 @@ query:
     - store.example.local:10901
   queryReplicaLabel: replica
 
-  # cert, key and ca are base64 encoded strings
+  # cert, key and ca are strings and can be overwritten using `helm install <chart> --set-file <key>=/path/to/file`
   tlsClient:
     enabled: false
+    # certificate and key for client side authentication to stores
     cert: ""
     key: ""
+    # CA to validate the remote store certificate
     ca: ""
+    # (optional) server name indication to the stores (ref: https://tools.ietf.org/html/rfc4366#section-3.1)
     serverName: ""
 
-  # cert, key and ca are base64 encoded strings
+  # cert, key and ca are strings and can be overwritten using `helm install <chart> --set-file <key>=/path/to/file`
   tlsServer:
     enabled: false
+    # certificate and key for server TLS
     cert: ""
     key: ""
+    # CA to validate the remote client certificate
     ca: ""
 
   deployment:


### PR DESCRIPTION
@arthur-c two important notes:

1. The S3 usage here is deprecated and needs to be removed (I added a TODO there)
2. There is **one breaking change** I couldn't avoid with creating the TLS secrets, since I wanted to be able to use `helm install <chart> --set-file key=/path/to/file` and couldn't have done it without adding `b64enc`